### PR TITLE
Bugfix camera switch Android/iOS 

### DIFF
--- a/TestSample/TestSample.Android/Implementations/ConferenceManagerSpecificPlatformAndroid.cs
+++ b/TestSample/TestSample.Android/Implementations/ConferenceManagerSpecificPlatformAndroid.cs
@@ -435,18 +435,20 @@ namespace TestSample.Droid.Implementations
         }
         public void SwitchCamera()
         {
+            CameraFacing SwitchCurrentCamera =null;
             switch (CurrentCamera)
             {
                 case SelectedCamera.Front:
+                    SwitchCurrentCamera = CameraFacing.Back;
                     CurrentCamera = SelectedCamera.Back;
-                    _videoDeviceInfo = _deviceManager.Cameras.First(c => c.CameraFacing == CameraFacing.Back);
                     break;
                 case SelectedCamera.Back:
+                    SwitchCurrentCamera = CameraFacing.Front;
                     CurrentCamera = SelectedCamera.Front;
-                    _videoDeviceInfo = _deviceManager.Cameras.First(c => c.CameraFacing == CameraFacing.Front);
-                    break;
+                        break;
             }
-            CallClientHelper.SwitchCameraSource(_localVideoStream, _videoDeviceInfo);
+            var switchCurrentCamera = _deviceManager.Cameras.Where(c => c.CameraFacing == SwitchCurrentCamera).FirstOrDefault();
+            CallClientHelper.SwitchCameraSource(_localVideoStream, switchCurrentCamera);
         }
         public void StartCamera()
         {

--- a/TestSample/TestSample.Android/Implementations/ConferenceManagerSpecificPlatformAndroid.cs
+++ b/TestSample/TestSample.Android/Implementations/ConferenceManagerSpecificPlatformAndroid.cs
@@ -448,7 +448,10 @@ namespace TestSample.Droid.Implementations
                         break;
             }
             var switchCurrentCamera = _deviceManager.Cameras.Where(c => c.CameraFacing == SwitchCurrentCamera).FirstOrDefault();
-            CallClientHelper.SwitchCameraSource(_localVideoStream, switchCurrentCamera);
+            if (switchCurrentCamera != null)
+            {
+                CallClientHelper.SwitchCameraSource(_localVideoStream, switchCurrentCamera);
+            }
         }
         public void StartCamera()
         {

--- a/TestSample/TestSample.iOS/Implementations/ConferenceManagerSpecificPlatformIos.cs
+++ b/TestSample/TestSample.iOS/Implementations/ConferenceManagerSpecificPlatformIos.cs
@@ -445,19 +445,19 @@ namespace TestSample.iOS.Implementations
         }
         public void SwitchCamera()
         {
-            ACSCameraFacing aCSCameraFacing = ACSCameraFacing.Unknown;
+            ACSCameraFacing SwitchCurrentCamera = ACSCameraFacing.Unknown;
             switch (CurrentCamera)
             {
                 case SelectedCamera.Front:
-                    aCSCameraFacing = ACSCameraFacing.Back;
+                    SwitchCurrentCamera = ACSCameraFacing.Back;
                     CurrentCamera = SelectedCamera.Back;
                     break;
                 case SelectedCamera.Back:
-                    aCSCameraFacing = ACSCameraFacing.Front;
+                    SwitchCurrentCamera = ACSCameraFacing.Front;
                     CurrentCamera = SelectedCamera.Front;
                     break;
             }
-            var switchCurrentCamera = _deviceManager.Cameras.FirstOrDefault(c => c.CameraFacing == aCSCameraFacing);
+            var switchCurrentCamera = _deviceManager.Cameras.FirstOrDefault(c => c.CameraFacing == SwitchCurrentCamera);
 
             if (switchCurrentCamera != null)
             {

--- a/TestSample/TestSample.iOS/Implementations/ConferenceManagerSpecificPlatformIos.cs
+++ b/TestSample/TestSample.iOS/Implementations/ConferenceManagerSpecificPlatformIos.cs
@@ -445,18 +445,21 @@ namespace TestSample.iOS.Implementations
         }
         public void SwitchCamera()
         {
+            ACSCameraFacing aCSCameraFacing = ACSCameraFacing.Unknown;
             switch (CurrentCamera)
             {
                 case SelectedCamera.Front:
+                    aCSCameraFacing = ACSCameraFacing.Back;
                     CurrentCamera = SelectedCamera.Back;
-                    _videoDeviceInfo = _deviceManager.Cameras.First(c => c.CameraFacing == ACSCameraFacing.Back);
                     break;
                 case SelectedCamera.Back:
+                    aCSCameraFacing = ACSCameraFacing.Front;
                     CurrentCamera = SelectedCamera.Front;
-                    _videoDeviceInfo = _deviceManager.Cameras.First(c => c.CameraFacing == ACSCameraFacing.Front);
                     break;
             }
-            if (_videoDeviceInfo != null)
+            var switchCurrentCamera = _deviceManager.Cameras.FirstOrDefault(c => c.CameraFacing == aCSCameraFacing);
+
+            if (switchCurrentCamera != null)
             {
                 void SwtichCameraCompleted(NSError onSwtichCameraError)
                 {
@@ -466,7 +469,7 @@ namespace TestSample.iOS.Implementations
 
                     return;
                 }
-                _localVideoStream.SwitchSource(_videoDeviceInfo, SwtichCameraCompleted);
+                _localVideoStream.SwitchSource(switchCurrentCamera, SwtichCameraCompleted);
             }
 
         }


### PR DESCRIPTION
Partial fix of items related to bug #37

> On iOS and Android: The Camera switching (Back / Front camera) button is not working along the Video call

